### PR TITLE
Osamostatneni cli skriptu a pridani do package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,16 @@
   "name": "versioner",
   "version": "1.0.1",
   "description": "",
-  "main": "dist/src/index.js",
+  "main": "./dist/src/index.js",
+  "bin": {
+    "versioner": "./dist/src/cli.js"
+  },
   "author": "MWarCZ",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MWarCZ/versioner.git"
+  },
   "env": {
     "path": {
       "dist": "dist",
@@ -12,7 +19,8 @@
     }
   },
   "scripts": {
-    "start": "node $npm_package_main",
+    "env": "env | sort | grep ^npm_ | less",
+    "start": "node $npm_package_bin_versioner",
     "prebuild": "$npm_execpath run build:clean",
     "build": "$npm_execpath run tsc",
     "build:clean": "rimraf $npm_package_env_path_dist",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { main } from './app'
+
+main(process.argv).then(exitCode => process.exit(exitCode))


### PR DESCRIPTION
 # Co:
1. Vytvoren samostatny soubor pro cli skript/aplikaci.
2. Do package.json pridan odkaz bin na umisteni cli skriptu/aplikace.
 # Proc:
1. V souboru index.ts bude lepsi mit jen export funkci.
     - Jedna se o pripravu na oddeleni cli a knihovny.
     - V budoucnu snazsi rozsiritelnost o dalsi cli skripty/aplikace.
2. Pro spousteni cli v lokalni ci globalni instalaci.
   - Je nutne nastavit `bin` na cestu k cli skriptu/aplikaci.
      - Jinak funguje jen import a nefunguje `npx` ci `yarn`.
   - Spousteni pri globalni instalaci:
      - `versioner`
   - Spousteni pri lokalni instalaci:
      - `npx versioner` nebo `yarn versioner`